### PR TITLE
Release and CI stuff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@
 #   * Create GitHub Release "v$version"
 #   * Publish API Docs
 
-name: Release and Publish
+name: release
 on:
   workflow_dispatch:
     inputs:
@@ -22,7 +22,7 @@ on:
         description: '(Required) The version to release. Must be a real version, not a SNAPSHOT (ie. ending in "-SNAPSHOT"). For example "1.0.0", "1.0.0-alpha-1".'
         required: true
 jobs:
-  release-publish-tbd-artifactory:
+  release-artifactory:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -84,8 +84,8 @@ jobs:
           SIGN_KEY_PASS: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           SIGN_KEY: ${{ secrets.GPG_SECRET_KEY }}
 
-  publish-publicly:
-    needs: release-publish-tbd-artifactory
+  release-maven-central:
+    needs: release-artifactory
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -136,9 +136,9 @@ jobs:
           prerelease: false
           generate_release_notes: true
 
-  deploy-api-docs:
+  publish-docs:
     runs-on: ubuntu-latest
-    needs: [publish-publicly]
+    needs: [release-maven-central]
     steps:
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,152 @@
+# Kicks off the release process:
+#
+# * Sets release version
+# * Builds
+# * Tests
+# * Creates artifacts for binaries and sources
+# * Signs artifacts
+# * Uploads artifacts to TBD Artifactory
+# * Tags git with release number "v$version"
+# * Keeps development version in the pom.xml to 0.0.0-main-SNAPSHOT
+# * Pushes changes to git
+# * Triggers job to:
+#   * Build from tag and upload to Maven Central
+#   * Create GitHub Release "v$version"
+#   * Publish API Docs
+
+name: Release and Publish
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '(Required) The version to release. Must be a real version, not a SNAPSHOT (ie. ending in "-SNAPSHOT"). For example "1.0.0", "1.0.0-alpha-1".'
+        required: true
+jobs:
+  release-publish-tbd-artifactory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.TBD_RELEASE_GITHUB_PERSONAL_ACCESS_TOKEN }}
+
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      # Used in writing commits in the release process
+      - name: Set Git Config
+        run: |
+          git config user.name "tbd-releases"
+          git config user.email "releases@tbd.email"
+
+      # This will set versions, git tag, sign, and publish to TBD Artifactory. Does not release to Maven Central.
+      - name: Release and Publish to TBD Artifactory
+        run: |
+
+          # Get the required provided version
+          version=${{ github.event.inputs.version }}
+          # Precondition check; do not allow this to proceed if a version ending in "-SNAPSHOT" was specified
+          if [[ $version =~ -SNAPSHOT$ ]]; then
+            echo "Error: The version for release must not end with \"-SNAPSHOT\": $version"
+            exit 1
+          fi
+
+          # Get the existing version from the POM and set it to the nextVersion, keeping the POM effectively versionless
+          nextVersion=$(grep -oPm1 "(?<=<version>)[^<]+" pom.xml) 
+          if [[ -z $nextVersion ]]; then
+            echo "Error: Could not find a version in the pom.xml"
+            exit 1
+          fi
+
+          echo "Version to be released: $version"
+          echo "Setting next development version back to original in pom.xml: $nextVersion"
+
+          mvn -e \
+            release:prepare \
+            release:perform \
+            --batch-mode \
+            --settings .maven_settings.xml \
+            -DreleaseVersion=$version \
+            -DdevelopmentVersion=$nextVersion \
+            -P sign-artifacts
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          TBD_RELEASE_GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.TBD_RELEASE_GITHUB_PERSONAL_ACCESS_TOKEN }}
+          SIGN_KEY_PASS: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+          SIGN_KEY: ${{ secrets.GPG_SECRET_KEY }}
+
+  publish-publicly:
+    needs: release-publish-tbd-artifactory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ github.event.inputs.version }}
+          submodules: true
+
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build, Test, and Deploy to Maven Central
+        run: |
+          echo $(git describe --tags)
+          # Maven deploy lifecycle will build, run tests, verify, sign, and deploy
+          mvn \
+            deploy \
+              -P ossrh,sign-artifacts \
+              --batch-mode \
+              --settings .maven_settings.xml
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SIGN_KEY_PASS: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+          SIGN_KEY: ${{ secrets.GPG_SECRET_KEY }}
+
+      - name: Download Dokka CLI and Build HTML APIDocs
+        working-directory: .
+        run: ./dokka/gen.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: target/apidocs
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+
+  deploy-api-docs:
+    runs-on: ubuntu-latest
+    needs: [publish-publicly]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          path: public
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_dir: ./public
+          full_commit_message: Publish documentation to GitHub pages

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,0 +1,68 @@
+name: snapshot release
+
+# triggered manually via the GitHub Actions interface (workflow_dispatch). It is designed to publish 
+# a snapshot version of the sdk. useful for testing and debugging
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish. For example "1.0.0-SNAPSHOT". If not supplied, will default to version specified in the POM. Must end in "-SNAPSHOT".'
+        required: false
+        default: "0.0.0-SNAPSHOT"
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+        with:
+          cache: true
+
+      - name: Resolve Snapshot Version
+        id: resolve_version
+        run: |
+          # Version resolution: use provided
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            resolvedVersion=${{ github.event.inputs.version }}
+          # Otherwise, construct a version for deployment in form X.Y.Z-commit-$shortSHA-SNAPSHOT
+          else
+            longSHA=$(git rev-parse --verify HEAD)
+            shortSHA=$(echo "${longSHA:0:7}")
+            resolvedVersion="commit-$shortSHA-SNAPSHOT"
+            echo "Requesting deployment as version: $resolvedVersion"
+          fi
+
+          # Postcondition check; only allow this to proceed if we have a version ending in "-SNAPSHOT"
+          if [[ ! "$resolvedVersion" =~ -SNAPSHOT$ ]]; then
+            echo "Error: The version does not end with \"-SNAPSHOT\": $resolvedVersion"
+            exit 1
+          fi
+
+          echo "Resolved SNAPSHOT Version: $resolvedVersion"
+          echo "resolved_version=$resolvedVersion" >> $GITHUB_OUTPUT
+      - name: Build, Test, and Deploy to TBD Artifactory
+        run: |
+          # Set newly resolved version in POM config
+          mvn \
+            versions:set \
+            --batch-mode \
+            -DnewVersion=${{ steps.resolve_version.outputs.resolved_version }}
+
+          # Only attempt to publish artifact if we have credentials
+          if [ -n "${{ secrets.ARTIFACTORY_PASSWORD }}" ]; then
+            # Maven deploy lifecycle will build, run tests, verify, sign, and deploy
+            mvn deploy --batch-mode --settings .maven_settings.xml -P sign-artifacts
+          else
+            # Otherwise, Maven verify lifecycle will build, run tests, and verify
+            mvn verify --batch-mode
+          fi
+
+        env:
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          SIGN_KEY_PASS: ${{ secrets.GPG_SECRET_PASSPHRASE }}
+          SIGN_KEY: ${{ secrets.GPG_SECRET_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: test
 
+# triggered by push to main, pull request to main, or manual workflow dispatch. Runs tests on macOS and Ubuntu
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: test
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-macos:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+        with:
+          cache: true
+      - name: Build and Test
+        run: |
+          mvn test
+  test-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # https://cashapp.github.io/hermit/usage/ci/
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+        with:
+          cache: true
+      - name: Build and Test
+        run: |
+          mvn test

--- a/.maven_settings.xml
+++ b/.maven_settings.xml
@@ -1,0 +1,29 @@
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>tbd-releases</username>
+      <password>${env.TBD_RELEASE_GITHUB_PERSONAL_ACCESS_TOKEN}</password>
+    </server>
+    <server>
+      <id>tbd-oss-releases</id>
+      <username>${env.ARTIFACTORY_USERNAME}</username>
+      <password>${env.ARTIFACTORY_PASSWORD}</password>
+    </server>
+    <server>
+      <id>tbd-oss-snapshots</id>
+      <username>${env.ARTIFACTORY_USERNAME}</username>
+      <password>${env.ARTIFACTORY_PASSWORD}</password>
+    </server>
+    <server>
+      <id>ossrh-snapshots</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+    <server>
+      <id>ossrh-releases</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>xyz.block</groupId>
   <artifactId>dap</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.0.0-main-SNAPSHOT</version>
   <name>DAP SDK</name>
 
   <properties>
@@ -20,8 +20,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-
-      <!-- tbDEX Dependency Management (BOM)-->
       <dependency>
         <groupId>xyz.block</groupId>
         <artifactId>web5-parent</artifactId>
@@ -29,52 +27,9 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <!-- Kotlin -->
-      <dependency>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-stdlib</artifactId>
-        <version>${version.kotlin}</version>
-      </dependency>
-
-      <!-- Test Dependencies -->
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${version.org.assertj}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${version.org.junit.jupiter}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${version.org.junit.jupiter}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>${version.com.squareup.okhttp3}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.ktor</groupId>
-        <artifactId>ktor-server-test-host</artifactId>
-        <version>${version.io.ktor}</version>
-        <scope>test</scope>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>xyz.block</groupId>
@@ -87,90 +42,226 @@
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>
+      <version>${version.kotlin}</version>
     </dependency>
-
 
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <version>${version.org.assertj}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.org.junit.jupiter}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.org.junit.jupiter}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${version.com.squareup.okhttp3}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
   <build>
     <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
     <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>kotlin-maven-plugin</artifactId>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <version>${version.kotlin}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.0.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <deployAtEnd>true</deployAtEnd>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.simplify4u.plugins</groupId>
+        <artifactId>sign-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <pushChanges>true</pushChanges>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <scmCommentPrefix>[TBD Release Manager &#x1f680;]</scmCommentPrefix>
+          <scmReleaseCommitComment>@{prefix} Setting version to: @{releaseLabel}</scmReleaseCommitComment>
+          <scmDevelopmentCommitComment>@{prefix} Setting next development version after: @{releaseLabel}</scmDevelopmentCommitComment>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
       <plugin>
         <artifactId>kotlin-maven-plugin</artifactId>
         <groupId>org.jetbrains.kotlin</groupId>
+        <version>${version.kotlin}</version>
         <extensions>true</extensions>
         <configuration>
           <jvmTarget>${kotlin.jvm.target}</jvmTarget>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.ozsie</groupId>
+        <artifactId>detekt-maven-plugin</artifactId>
+        <version>1.23.5</version>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <config>config/detekt.yml</config>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.gitlab.arturbosch.detekt</groupId>
+            <artifactId>detekt-formatting</artifactId>
+            <version>1.23.5</version>
+          </dependency>
+          <dependency>
+            <groupId>com.github.TBD54566975</groupId>
+            <artifactId>tbd-detekt-rules</artifactId>
+            <version>0.0.2</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>sign-artifacts</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.simplify4u.plugins</groupId>
+            <artifactId>sign-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- https://central.sonatype.org/publish/publish-maven/#deployment -->
+      <id>ossrh</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.13</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh-releases</serverId>
+              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh-snapshots</id>
+          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <!-- Sonatype's OSSRH - replicates to Maven Central within 30min of publish -->
+        <repository>
+          <id>ossrh-releases</id>
+          <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+  </profiles>
+
+  <distributionManagement>
+    <repository>
+      <uniqueVersion>false</uniqueVersion>
+      <id>tbd-oss-releases</id>
+      <name>TBD OSS Releases Repository</name>
+      <url>https://blockxyz.jfrog.io/artifactory/tbd-oss-releases-maven2</url>
+      <layout>default</layout>
+    </repository>
+    <snapshotRepository>
+      <uniqueVersion>false</uniqueVersion>
+      <id>tbd-oss-snapshots</id>
+      <name>TBD OSS Snapshots Repository</name>
+      <url>https://blockxyz.jfrog.io/artifactory/tbd-oss-snapshots-maven2</url>
+      <layout>default</layout>
+    </snapshotRepository>
+  </distributionManagement>
 
   <repositories>
     <!-- 3rdparty dependencies of TBD Projects-->
@@ -207,4 +298,18 @@
       <snapshots/>
     </repository>
   </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>tbd-oss-thirdparty</id>
+      <name>tbd-oss-thirdparty</name>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <url>https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>


### PR DESCRIPTION
# Changes
* very slowly copy pasta'd a bunch of publish related stuff into pom file per suggestions made in #1 
* added a handful of GH workflows

# GH Workflows

## `test`
Runs tests on macOS and Ubuntu. triggered by push to main, pull request to main, or manual workflow dispatch. 

## `snapshot-release`
publishes a snapshot version of the sdk. useful for testing and debugging. triggered manually via the GitHub Actions interface (workflow_dispatch). 

## `release`
Kicks off the release process:
* Sets release version
* Builds
* Tests
* Creates artifacts for binaries and sources
* Signs artifacts
* Uploads artifacts to TBD Artifactory
* Tags git with release number `v$version`
* Keeps development version in the pom.xml to `0.0.0-main-SNAPSHOT`
* Pushes changes to git
* Triggers job to:
  * Build from tag and upload to Maven Central
  * Create GitHub Release `v$version`
  * Publish API Docs

