### PR TITLE
Release fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,8 @@
   <version>0.0.0-main-SNAPSHOT</version>
   <name>DAP SDK</name>
   <description>Decentralized Agnostic Paytag SDK for JVM</description>
-  <inceptionYear>2023</inceptionYear>
+  <url>https://github.com/TBD54566975/dap</url>
+  <inceptionYear>2024</inceptionYear>
 
   <scm>
     <connection>scm:git:git://github.com/TBD54566975/dap-kt.git</connection>
@@ -234,6 +235,19 @@
             <version>0.0.2</version>
           </dependency>
         </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.dokka</groupId>
+        <artifactId>dokka-maven-plugin</artifactId>
+        <version>1.9.20</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>javadocJar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
 
   <properties>
+    <project.scm.id>github</project.scm.id>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kotlin.jvm.target>11</kotlin.jvm.target>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,41 @@
   <artifactId>dap</artifactId>
   <version>0.0.0-main-SNAPSHOT</version>
   <name>DAP SDK</name>
+  <description>Decentralized Agnostic Paytag SDK for JVM</description>
+  <inceptionYear>2023</inceptionYear>
+
+  <scm>
+    <connection>scm:git:git://github.com/TBD54566975/dap-kt.git</connection>
+    <!-- This has to be HTTPS, not git://, for maven-release-plugin to do AUTH correctly -->
+    <developerConnection>scm:git:https://github.com/TBD54566975/dap-kt.git</developerConnection>
+    <url>https://github.com/TBD54566975/dap-kt</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <developers>
+    <developer>
+      <id>TBD54566975</id>
+      <name>Block, Inc.</name>
+      <email>releases@tbd.email</email>
+    </developer>
+  </developers>
+
+  <!-- Issues -->
+  <issueManagement>
+    <system>github</system>
+    <url>https://github.com/TBD54566975/dap-kt/issues</url>
+  </issueManagement>
+
+  <!-- Licenses -->
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
fixing release issues:

```
Error:  Rule failure while trying to close staging repository with ID "xyzblock-1410".
Error:  
Error:  Nexus Staging Rules Failure Report
Error:  ==================================
Error:  
Error:  Repository "xyzblock-1410" failures
Error:    Rule "pom-staging" failures
Error:      * Invalid POM: /xyz/block/dap/0.1.0/dap-0.1.0.pom: Project URL missing
Error:    Rule "javadoc-staging" failures
Error:      * Missing: no javadoc jar found in folder '/xyz/block/dap/0.1.0'
Error:  
Error:  
Error:  Cleaning up local stage directory after a Rule failure during close of staging repositories: [xyzblock-1410]
Error:   * Deleting context 3e962c2f9dd9b.properties
Error:  Cleaning up remote stage repositories after a Rule failure during close of staging repositories: [xyzblock-1410]
Error:   * Dropping failed staging repository with ID "xyzblock-1410" (Rule failure during close of staging repositories: [xyzblock-1410])
```