### PR TITLE
Docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: docs
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Generate API Docs
+        working-directory: .
+        run: ./dokka/gen.sh
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: docs
+          path: target/apidocs
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,18 +135,3 @@ jobs:
           draft: false
           prerelease: false
           generate_release_notes: true
-
-  publish-docs:
-    runs-on: ubuntu-latest
-    needs: [release-maven-central]
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          path: public
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          keep_files: true
-          publish_dir: ./public
-          full_commit_message: Publish documentation to GitHub pages

--- a/dokka/config.json
+++ b/dokka/config.json
@@ -1,5 +1,5 @@
 {
-  "moduleName": "DAP SDK",
+  "moduleName": "dap",
   "failOnWarning": false,
   "suppressObviousFunctions": true,
   "suppressInheritedMembers": false,


### PR DESCRIPTION
moves docs generation into its own workflow and uses github action pages deployment instead of `gh-pages` branch