### PR TITLE
Implement DAP resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <version.org.assertj>3.25.2</version.org.assertj>
     <version.org.junit.jupiter>5.10.1</version.org.junit.jupiter>
     <version.xyz.block.web5>1.1.2</version.xyz.block.web5>
+    <version.io.ktor>2.3.7</version.io.ktor>
     <version.kotlin>1.9.22</version.kotlin>
     <version.kotlin.compiler.incremental>true</version.kotlin.compiler.incremental>
   </properties>
@@ -98,6 +99,12 @@
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-test-junit5</artifactId>
       <version>${version.kotlin}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-client-mock-jvm</artifactId>
+      <version>${version.io.ktor}</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/kotlin/xyz/block/dap/Dap.kt
+++ b/src/main/kotlin/xyz/block/dap/Dap.kt
@@ -14,6 +14,8 @@ data class Dap(
     const val PREFIX = "@"
     const val SEPARATOR = "/"
 
+    const val SERVICE_TYPE = "dapregistry"
+
     private const val DAP_REGEX = """^$PREFIX([^$PREFIX$SEPARATOR]+)$SEPARATOR([^$PREFIX$SEPARATOR]+)$"""
     private val DAP_PATTERN = Pattern.compile(DAP_REGEX)
 

--- a/src/main/kotlin/xyz/block/dap/DapResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/DapResolver.kt
@@ -5,13 +5,14 @@ import xyz.block.maddr.MoneyAddress
 // This implements the DAP resolution process
 // See the [DAP spec](https://github.com/TBD54566975/dap#resolution)
 class DapResolver(
-  val registryResolver: RegistryResolver,
-  val registryDidResolver: RegistryDidResolver,
-  val moneyAddressResolver: MoneyAddressResolver
+  private val registryResolver: RegistryResolver = RegistryResolver(),
+  private val registryDidResolver: RegistryDidResolver = RegistryDidResolver {},
+  private val moneyAddressResolver: MoneyAddressResolver = MoneyAddressResolver()
 ) {
   fun resolveMoneyAddresses(dap: Dap): List<MoneyAddress> {
     val registryUrl = registryResolver.resolveRegistryUrl(dap)
     val did = registryDidResolver.getDid(registryUrl, dap)
-    return moneyAddressResolver.resolveMoneyAddresses(did)
+    val moneyAddresses = moneyAddressResolver.resolveMoneyAddresses(did)
+    return moneyAddresses
   }
 }

--- a/src/main/kotlin/xyz/block/dap/DapResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/DapResolver.kt
@@ -1,0 +1,17 @@
+package xyz.block.dap
+
+import xyz.block.maddr.MoneyAddress
+
+// This implements the DAP resolution process
+// See the [DAP spec](https://github.com/TBD54566975/dap#resolution)
+class DapResolver(
+  val registryResolver: RegistryResolver,
+  val registryDidResolver: RegistryDidResolver,
+  val moneyAddressResolver: MoneyAddressResolver
+) {
+  fun resolveMoneyAddresses(dap: Dap): List<MoneyAddress> {
+    val registryUrl = registryResolver.resolveRegistryUrl(dap)
+    val did = registryDidResolver.getDid(registryUrl, dap)
+    return moneyAddressResolver.resolveMoneyAddresses(did)
+  }
+}

--- a/src/main/kotlin/xyz/block/dap/MoneyAddressResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/MoneyAddressResolver.kt
@@ -1,0 +1,39 @@
+package xyz.block.dap
+
+import web5.sdk.dids.DidResolvers
+import web5.sdk.dids.didcore.Did
+import web5.sdk.dids.didcore.DidDocument
+import xyz.block.maddr.MoneyAddress
+import xyz.block.maddr.toMoneyAddresses
+
+// This implements part of the DAP resolution process.
+// See [Resolver] for the full resolution process.
+// See the [DAP spec](https://github.com/TBD54566975/dap#resolution)
+class MoneyAddressResolver {
+
+  fun resolveMoneyAddresses(did: Did): List<MoneyAddress> {
+    val didDocument = resolveDidDocument(did)
+    val moneyAddresses = parseDidDocumentForMoneyAddresses(didDocument)
+    return moneyAddresses
+  }
+
+  private fun resolveDidDocument(did: Did): DidDocument {
+    val didResolutionResult = try {
+      DidResolvers.resolve(did.toString())
+    } catch (e: Throwable) {
+      throw MoneyAddressResolutionException("DID resolution failed", e)
+    }
+    didResolutionResult.didDocument?.let { return it }
+    throw MoneyAddressResolutionException("DID resolution failed with no document found")
+  }
+
+  private fun parseDidDocumentForMoneyAddresses(didDocument: DidDocument): List<MoneyAddress> {
+    return didDocument.service?.find { it.type == MoneyAddress.KIND }?.toMoneyAddresses()
+      ?: emptyList()
+  }
+}
+
+class MoneyAddressResolutionException : Throwable {
+  constructor(message: String, cause: Throwable?) : super(message, cause)
+  constructor(message: String) : super(message)
+}

--- a/src/main/kotlin/xyz/block/dap/RegistryDidResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/RegistryDidResolver.kt
@@ -1,0 +1,24 @@
+package xyz.block.dap
+
+import web5.sdk.dids.didcore.Did
+import java.net.URL
+
+// This implements part of the DAP resolution process.
+// See [Resolver] for the full resolution process.
+// See the [DAP spec](https://github.com/TBD54566975/dap#resolution)
+class RegistryDidResolver {
+
+  fun getDid(dapResistryUrl: URL, dap: Dap): Did {
+    // TODO - implement this
+    // val fullUrl = URL("$dapResistryUrl/daps/${dap.handle}")
+    // call GET on the dapRegistryUrl to get the did for the document with the money addresses
+    // TODO - should we validate the proof here?
+    // parse the result document to get the did
+    return Did.parse("did:web:didpay.me:moegrammer")
+  }
+}
+
+class RegistryDidResolutionException : Throwable {
+  constructor(message: String, cause: Throwable?) : super(message, cause)
+  constructor(message: String) : super(message)
+}

--- a/src/main/kotlin/xyz/block/dap/RegistryDidResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/RegistryDidResolver.kt
@@ -1,21 +1,108 @@
 package xyz.block.dap
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import io.ktor.serialization.jackson.jackson
+import kotlinx.coroutines.runBlocking
+import okhttp3.Cache
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import web5.sdk.common.Json
 import web5.sdk.dids.didcore.Did
+import java.io.File
+import java.net.InetAddress
 import java.net.URL
+import java.net.UnknownHostException
 
 // This implements part of the DAP resolution process.
 // See [Resolver] for the full resolution process.
 // See the [DAP spec](https://github.com/TBD54566975/dap#resolution)
-class RegistryDidResolver {
 
-  fun getDid(dapResistryUrl: URL, dap: Dap): Did {
-    // TODO - implement this
-    // val fullUrl = URL("$dapResistryUrl/daps/${dap.handle}")
-    // call GET on the dapRegistryUrl to get the did for the document with the money addresses
-    // TODO - should we validate the proof here?
-    // parse the result document to get the did
-    return Did.parse("did:web:didpay.me:moegrammer")
+class RegistryDidResolver(
+  configuration: RegistryDidResolverConfiguration
+) {
+  private val engine: HttpClientEngine = configuration.engine ?: OkHttp.create {
+    val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
+    val bootstrapClient = OkHttpClient.Builder().cache(appCache).build()
+
+    val dns = DnsOverHttps.Builder()
+      .client(bootstrapClient)
+      .url("https://dns.quad9.net/dns-query".toHttpUrl())
+      .bootstrapDnsHosts(
+        InetAddress.getByName("9.9.9.9"),
+        InetAddress.getByName("149.112.112.112")
+      )
+      .build()
+
+    val client = bootstrapClient.newBuilder().dns(dns).build()
+    preconfigured = client
   }
+
+  private val client = HttpClient(engine) {
+    install(ContentNegotiation) {
+      jackson { mapper }
+    }
+  }
+
+  private val mapper = Json.jsonMapper
+
+  fun getDid(dapRegistryUrl: URL, dap: Dap): Did {
+    val fullUrl = URL("$dapRegistryUrl/daps/${dap.handle}")
+
+    val resp: HttpResponse = try {
+      runBlocking {
+        client.get(fullUrl) {
+          contentType(ContentType.Application.Json)
+        }
+      }
+    } catch (e: UnknownHostException) {
+      throw RegistryDidResolutionException("Failed to reach DAP Registry", e)
+    }
+
+    val body = runBlocking { resp.bodyAsText() }
+    if (!resp.status.isSuccess()) {
+      throw RegistryDidResolutionException("Failed to read from DAP registry")
+    }
+    val resolutionResponse = mapper.readValue(body, DapRegistryResolutionResponse::class.java)
+    // TODO - should we verify the proof here?
+    if (resolutionResponse.did == null) {
+      throw RegistryDidResolutionException("DAP registry did not return a DID")
+    }
+
+    return Did.parse(resolutionResponse.did)
+  }
+}
+
+class Proof(
+  val id: String,
+  val handle: String,
+  val did: String,
+  val domain: String,
+  val signature: String
+)
+
+class DapRegistryResolutionResponse(
+  val did: String?,
+  @JsonIgnore val proof: Proof?
+)
+
+class RegistryDidResolverConfiguration internal constructor(
+  var engine: HttpClientEngine? = null
+)
+
+fun RegistryDidResolver(configuration: RegistryDidResolverConfiguration.() -> Unit): RegistryDidResolver {
+  val config = RegistryDidResolverConfiguration().apply(configuration)
+  return RegistryDidResolver(config)
 }
 
 class RegistryDidResolutionException : Throwable {

--- a/src/main/kotlin/xyz/block/dap/RegistryResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/RegistryResolver.kt
@@ -1,0 +1,55 @@
+package xyz.block.dap
+
+import web5.sdk.dids.DidResolutionResult
+import web5.sdk.dids.DidResolvers
+import web5.sdk.dids.didcore.Service
+import java.net.URL
+
+// This implements part of the DAP resolution process.
+// See [Resolver] for the full resolution process.
+// See the [DAP spec](https://github.com/TBD54566975/dap#resolution)
+class RegistryResolver {
+
+  fun resolveRegistryUrl(dap: Dap): URL {
+    val did = dap.toWebDid()
+    val didResolutionResult = resolveDid(did)
+    val dapRegistryService = findDapRegistryService(didResolutionResult)
+    val dapRegistryUrl = findDapRegistryUrl(dapRegistryService)
+    try {
+      return URL(dapRegistryUrl)
+    } catch (e: Throwable) {
+      throw RegistryResolutionException("Invalid DAP registry url", e)
+    }
+  }
+
+  private fun resolveDid(did: String): DidResolutionResult {
+    try {
+      return DidResolvers.resolve(did)
+    } catch (e: Throwable) {
+      throw RegistryResolutionException("DID resolution failed", e)
+    }
+  }
+
+  private fun findDapRegistryService(didResolutionResult: DidResolutionResult): Service =
+    didResolutionResult.didDocument?.service?.find { it.type == Dap.SERVICE_TYPE }
+      ?: throw RegistryResolutionException("DAP registry service not found")
+
+  private fun findDapRegistryUrl(dapRegistryService: Service): String {
+    if (dapRegistryService.serviceEndpoint.size != 1) {
+      throw RegistryResolutionException("DAP registry has no service endpoints")
+    }
+    // TODO - feedback to web5-kt, should this be a list or a single string?
+    return dapRegistryService.serviceEndpoint[0]
+  }
+
+  companion object {
+    fun Dap.toWebDid(): String {
+      return "did:web:${domain}"
+    }
+  }
+}
+
+class RegistryResolutionException : Throwable {
+  constructor(message: String, cause: Throwable?) : super(message, cause)
+  constructor(message: String) : super(message)
+}

--- a/src/test/kotlin/xyz/block/dap/MoneyAddressResolverTest.kt
+++ b/src/test/kotlin/xyz/block/dap/MoneyAddressResolverTest.kt
@@ -1,0 +1,72 @@
+package xyz.block.dap
+
+import web5.sdk.dids.DidResolutionResult
+import web5.sdk.dids.DidResolvers
+import web5.sdk.dids.didcore.Did
+import web5.sdk.dids.didcore.DidDocument
+import web5.sdk.dids.didcore.Service
+import web5.sdk.dids.methods.web.DidWeb
+import xyz.block.maddr.MoneyAddress
+import xyz.block.maddr.urn.Urn
+import java.util.UUID
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MoneyAddressResolverTest {
+
+  @BeforeTest
+  fun beforeTest() {
+  }
+
+  @AfterTest
+  fun afterTest() {
+    DidResolvers.addResolver(DidWeb.methodName, DidWeb.Default::resolve)
+  }
+
+  @Test
+  fun testResolvingRegistryUrlFromDap() {
+    stubDidResolver(listOf(serviceForEndpoint("btc-on-chain", VALID_BITCOIN_ADDRESS_URN.toString())))
+
+    val moneyAddressResolver = MoneyAddressResolver()
+    val moneyAddresses = moneyAddressResolver.resolveMoneyAddresses(VALID_DID)
+    assertEquals(1, moneyAddresses.size)
+    assertEquals(
+      MoneyAddress(
+        id = "btc-on-chain",
+        urn = VALID_BITCOIN_ADDRESS_URN,
+        currency = VALID_BITCOIN_ADDRESS_URN_CURRENCY,
+        css = VALID_BITCOIN_ADDRESS_URN_CSS,
+      ), moneyAddresses[0]
+    )
+  }
+
+  // TODO - tests for error cases
+
+  private fun serviceForEndpoint(id: String, serviceEndpoint: String): Service {
+    return Service.Builder()
+      .id(id)
+      .type(MoneyAddress.KIND)
+      .serviceEndpoint(listOf(serviceEndpoint))
+      .build()
+  }
+
+  private fun stubDidResolver(services: List<Service>) {
+    DidResolvers.addResolver(DidWeb.methodName) { _ ->
+      DidResolutionResult(
+        didDocument = DidDocument(
+          id = UUID.randomUUID().toString(),
+          service = services
+        )
+      )
+    }
+  }
+
+  companion object {
+    val VALID_DID = Did.parse("did:web:didpay.me")
+    val VALID_BITCOIN_ADDRESS_URN = Urn.parse("urn:btc:addr:fakeAddress")
+    const val VALID_BITCOIN_ADDRESS_URN_CURRENCY = "btc"
+    const val VALID_BITCOIN_ADDRESS_URN_CSS = "addr:fakeAddress"
+  }
+}

--- a/src/test/kotlin/xyz/block/dap/RegistryDidResolverTest.kt
+++ b/src/test/kotlin/xyz/block/dap/RegistryDidResolverTest.kt
@@ -1,0 +1,32 @@
+package xyz.block.dap
+
+import web5.sdk.dids.didcore.Did
+import java.net.URL
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RegistryDidResolverTest {
+
+  @BeforeTest
+  fun beforeTest() {
+  }
+
+  @AfterTest
+  fun afterTest() {
+  }
+
+  @Test
+  fun testResolvingDidFromRegistryUrl() {
+    val registryDidResolver = RegistryDidResolver()
+    val did = registryDidResolver.getDid(VALID_URL, VALID_DAP)
+    assertEquals(VALID_DID.toString(), did.toString())
+  }
+
+  companion object {
+    val VALID_URL = URL("https://didpay.me")
+    val VALID_DAP = Dap("moegrammer", "didpay.me")
+    val VALID_DID = Did.parse("did:web:didpay.me:moegrammer")
+  }
+}

--- a/src/test/kotlin/xyz/block/dap/RegistryResolverTest.kt
+++ b/src/test/kotlin/xyz/block/dap/RegistryResolverTest.kt
@@ -1,0 +1,91 @@
+package xyz.block.dap
+
+import org.junit.jupiter.api.assertThrows
+import web5.sdk.dids.DidResolutionResult
+import web5.sdk.dids.DidResolvers
+import web5.sdk.dids.didcore.DidDocument
+import web5.sdk.dids.didcore.Service
+import web5.sdk.dids.methods.web.DidWeb
+import java.util.UUID
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RegistryDapResolverTest {
+
+  @BeforeTest
+  fun beforeTest() {
+    stubDidResolver(listOf(serviceForEndpoint(VALID_SERVICE_ENDPOINT)))
+  }
+
+  @AfterTest
+  fun afterTest() {
+    DidResolvers.addResolver(DidWeb.methodName, DidWeb.Default::resolve)
+  }
+
+  @Test
+  fun testResolvingRegistryUrlFromDap() {
+    val registryResolver = RegistryResolver()
+    val url = registryResolver.resolveRegistryUrl(VALID_DAP)
+    assertEquals("$VALID_SERVICE_ENDPOINT", url.toString())
+  }
+
+  @Test
+  fun testResolvingRegistryUrlWhenDidResolutionFails() {
+    DidResolvers.addResolver(DidWeb.methodName) { _ ->
+      throw RuntimeException("boom!")
+    }
+    val registryResolver = RegistryResolver()
+    val exception = assertThrows<RegistryResolutionException> {
+      registryResolver.resolveRegistryUrl(VALID_DAP)
+    }
+    assertEquals("DID resolution failed", exception.message)
+    assertEquals("boom!", exception.cause?.message)
+  }
+
+  @Test
+  fun testResolvingRegistryUrlWhenDidHasNoDapRegistryService() {
+    stubDidResolver(emptyList())
+    val registryResolver = RegistryResolver()
+    val exception = assertThrows<RegistryResolutionException> {
+      registryResolver.resolveRegistryUrl(VALID_DAP)
+    }
+    assertEquals("DAP registry service not found", exception.message)
+  }
+
+  @Test
+  fun testResolvingRegistryUrlWhenDapRegistryHasInvalidServiceEndpoint() {
+    stubDidResolver(listOf(serviceForEndpoint("not-a-valid-service-endpoint")))
+    val registryResolver = RegistryResolver()
+    val exception = assertThrows<RegistryResolutionException> {
+      registryResolver.resolveRegistryUrl(VALID_DAP)
+    }
+    assertEquals("Invalid DAP registry url", exception.message)
+    assertEquals("no protocol: not-a-valid-service-endpoint", exception.cause?.message)
+  }
+
+  private fun serviceForEndpoint(serviceEndpoint: String): Service {
+    return Service.Builder()
+      .id(UUID.randomUUID().toString())
+      .type(Dap.SERVICE_TYPE)
+      .serviceEndpoint(listOf(serviceEndpoint))
+      .build()
+  }
+
+  private fun stubDidResolver(services: List<Service>) {
+    DidResolvers.addResolver(DidWeb.methodName) { _ ->
+      DidResolutionResult(
+        didDocument = DidDocument(
+          id = UUID.randomUUID().toString(),
+          service = services
+        )
+      )
+    }
+  }
+
+  companion object {
+    val VALID_DAP = Dap("valid-dap-handle", "valid-dap-domain")
+    const val VALID_SERVICE_ENDPOINT = "https://dap.didpay.xyz"
+  }
+}


### PR DESCRIPTION
Implement DAP resolution via DapResolver

This is implemented in three classes that can used individually, or overridden in the DapResolver if required

- RegistryResolver
  - maps the DAP to a web did
  - resolves the web did
  - returns the "dapregistry" service endpoint URL

- RegistryDidResolver
  - constructs the full url for the dap registry (e.g. https://didpay.me/daps/moegrammer)
  - fetches the did response from the registry
  - parses the response to get the did

- MoneyAddressResolver
  - resolves the did
  - finds the "maddr" service endpoints
  - returns the endpoints as a list of MoneyAddress objects
 