### PR TITLE
fix RegistryDidResolver issues

### DIFF
--- a/src/main/kotlin/xyz/block/dap/DapResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/DapResolver.kt
@@ -3,31 +3,33 @@ package xyz.block.dap
 import xyz.block.moneyaddress.MoneyAddress
 
 /**
- * Resolves a Decentralized Agnostic Paytag (DAP)
+ * Resolves a Decentralized Agnostic Paytag (DAP).
  * See the [DAP spec](https://github.com/TBD54566975/dap#resolution) for the resolution process.
  *
- * This wires together the RegistryResolver, RegistryDidResolver, and MoneyAddressResolver
- * The
+ * This wires together the RegistryResolver, RegistryDidResolver, and MoneyAddressResolver.
+ * The RegistryDidResolver will use the default configuration unless an instance is provided that
+ * is constructed with a block configuration override.
  */
 class DapResolver(
-  private val registryDidResolver: RegistryDidResolver = defaultRegistryDidResolver(),
+  private val registryDidResolver: RegistryDidResolver = RegistryDidResolver(),
 ) {
   private val registryResolver: RegistryResolver = RegistryResolver()
   private val moneyAddressResolver: MoneyAddressResolver = MoneyAddressResolver()
 
   /**
-   * Resolves the money addresses for a DAP
-   * This wires together the RegistryResolver, RegistryDidResolver, and MoneyAddressResolver
-   * This does NOT verify the proof of the DID
+   * Resolves the money addresses for a DAP.
+   * This does NOT verify the proof of the DID returned by the registry.
    *
    * @param dap the DAP to resolve
    * @return the list of money addresses for the DAP
    */
   fun resolveMoneyAddresses(dap: Dap): List<MoneyAddress> {
     val registryUrl = registryResolver.resolveRegistryUrl(dap)
-    // TODO - should we verify the proof here?
     val did = registryDidResolver.getUnprovenDid(registryUrl, dap)
     val moneyAddresses = moneyAddressResolver.resolveMoneyAddresses(did)
     return moneyAddresses
   }
+
+  // TODO - either use the registryDidResolver.getProvenDid above, or add a method
+  // `resolveProvenMoneyAddresses` that verifies the proof of the DID returned by the registry
 }

--- a/src/main/kotlin/xyz/block/dap/DapResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/DapResolver.kt
@@ -2,16 +2,31 @@ package xyz.block.dap
 
 import xyz.block.moneyaddress.MoneyAddress
 
-// This implements the DAP resolution process
-// See the [DAP spec](https://github.com/TBD54566975/dap#resolution)
+/**
+ * Resolves a Decentralized Agnostic Paytag (DAP)
+ * See the [DAP spec](https://github.com/TBD54566975/dap#resolution) for the resolution process.
+ *
+ * This wires together the RegistryResolver, RegistryDidResolver, and MoneyAddressResolver
+ * The
+ */
 class DapResolver(
-  private val registryResolver: RegistryResolver = RegistryResolver(),
-  private val registryDidResolver: RegistryDidResolver = RegistryDidResolver {},
-  private val moneyAddressResolver: MoneyAddressResolver = MoneyAddressResolver()
+  private val registryDidResolver: RegistryDidResolver = defaultRegistryDidResolver(),
 ) {
+  private val registryResolver: RegistryResolver = RegistryResolver()
+  private val moneyAddressResolver: MoneyAddressResolver = MoneyAddressResolver()
+
+  /**
+   * Resolves the money addresses for a DAP
+   * This wires together the RegistryResolver, RegistryDidResolver, and MoneyAddressResolver
+   * This does NOT verify the proof of the DID
+   *
+   * @param dap the DAP to resolve
+   * @return the list of money addresses for the DAP
+   */
   fun resolveMoneyAddresses(dap: Dap): List<MoneyAddress> {
     val registryUrl = registryResolver.resolveRegistryUrl(dap)
-    val did = registryDidResolver.getDid(registryUrl, dap)
+    // TODO - should we verify the proof here?
+    val did = registryDidResolver.getUnprovenDid(registryUrl, dap)
     val moneyAddresses = moneyAddressResolver.resolveMoneyAddresses(did)
     return moneyAddresses
   }

--- a/src/main/kotlin/xyz/block/dap/RegistryDidResolver.kt
+++ b/src/main/kotlin/xyz/block/dap/RegistryDidResolver.kt
@@ -1,6 +1,6 @@
 package xyz.block.dap
 
-import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
@@ -30,6 +30,39 @@ import java.net.UnknownHostException
 class RegistryDidResolver(
   configuration: RegistryDidResolverConfiguration
 ) {
+  data class DidWithProof(
+    val did: Did,
+    val proof: Proof?
+  )
+
+  fun getUnprovenDid(dapRegistryUrl: URL, dap: Dap): Did =
+    getDidWithProof(dapRegistryUrl, dap).did
+
+  fun getDidWithProof(dapRegistryUrl: URL, dap: Dap): DidWithProof {
+    val fullUrl = URL("$dapRegistryUrl/daps/${dap.handle}")
+
+    val resp: HttpResponse = try {
+      runBlocking {
+        client.get(fullUrl) {
+          contentType(ContentType.Application.Json)
+        }
+      }
+    } catch (e: UnknownHostException) {
+      throw RegistryDidResolutionException("Failed to reach DAP Registry", e)
+    }
+
+    val body = runBlocking { resp.bodyAsText() }
+    if (!resp.status.isSuccess()) {
+      throw RegistryDidResolutionException("Failed to read from DAP registry")
+    }
+    val resolutionResponse = mapper.readValue(body, DapRegistryResolutionResponse::class.java)
+    if (resolutionResponse.did == null) {
+      throw RegistryDidResolutionException("DAP registry did not return a DID")
+    }
+
+    return DidWithProof(Did.parse(resolutionResponse.did), resolutionResponse.proof)
+  }
+
   private val engine: HttpClientEngine = configuration.engine ?: OkHttp.create {
     val appCache = Cache(File("cacheDir", "okhttpcache"), 10 * 1024 * 1024)
     val bootstrapClient = OkHttpClient.Builder().cache(appCache).build()
@@ -54,35 +87,10 @@ class RegistryDidResolver(
   }
 
   private val mapper = Json.jsonMapper
-
-  fun getDid(dapRegistryUrl: URL, dap: Dap): Did {
-    val fullUrl = URL("$dapRegistryUrl/daps/${dap.handle}")
-
-    val resp: HttpResponse = try {
-      runBlocking {
-        client.get(fullUrl) {
-          contentType(ContentType.Application.Json)
-        }
-      }
-    } catch (e: UnknownHostException) {
-      throw RegistryDidResolutionException("Failed to reach DAP Registry", e)
-    }
-
-    val body = runBlocking { resp.bodyAsText() }
-    if (!resp.status.isSuccess()) {
-      throw RegistryDidResolutionException("Failed to read from DAP registry")
-    }
-    val resolutionResponse = mapper.readValue(body, DapRegistryResolutionResponse::class.java)
-    // TODO - should we verify the proof here?
-    if (resolutionResponse.did == null) {
-      throw RegistryDidResolutionException("DAP registry did not return a DID")
-    }
-
-    return Did.parse(resolutionResponse.did)
-  }
 }
 
-class Proof(
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Proof(
   val id: String,
   val handle: String,
   val did: String,
@@ -90,16 +98,21 @@ class Proof(
   val signature: String
 )
 
-class DapRegistryResolutionResponse(
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class DapRegistryResolutionResponse(
   val did: String?,
-  @JsonIgnore val proof: Proof?
+  val proof: Proof?
 )
 
 class RegistryDidResolverConfiguration internal constructor(
   var engine: HttpClientEngine? = null
 )
 
-fun RegistryDidResolver(configuration: RegistryDidResolverConfiguration.() -> Unit): RegistryDidResolver {
+fun defaultRegistryDidResolver() : RegistryDidResolver {
+  return customRegistryDidResolver {}
+}
+
+fun customRegistryDidResolver(configuration: RegistryDidResolverConfiguration.() -> Unit): RegistryDidResolver {
   val config = RegistryDidResolverConfiguration().apply(configuration)
   return RegistryDidResolver(config)
 }

--- a/src/test/kotlin/xyz/block/dap/RegistryDidResolverTest.kt
+++ b/src/test/kotlin/xyz/block/dap/RegistryDidResolverTest.kt
@@ -6,46 +6,50 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
+import org.junit.jupiter.api.assertThrows
 import web5.sdk.dids.didcore.Did
 import java.net.URL
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class RegistryDidResolverTest {
 
-  @BeforeTest
-  fun beforeTest() {
-  }
-
-  @AfterTest
-  fun afterTest() {
-  }
+  private val registryDidResolver = RegistryDidResolver { engine = mockEngine() }
 
   @Test
   fun testResolvingDidFromRegistryUrl() {
-    val registryDidResolver = customRegistryDidResolver { engine = mockEngine() }
     val did = registryDidResolver.getUnprovenDid(VALID_URL, VALID_DAP)
     assertEquals(VALID_DID.toString(), did.toString())
   }
 
   @Test
+  fun testResolvingDidWithExtraFieldsFromRegistryUrl() {
+    val did = registryDidResolver.getUnprovenDid(VALID_URL, VALID_DAP_WITH_EXTRA_FIELDS)
+    assertEquals(VALID_DID.toString(), did.toString())
+  }
+
+  @Test
   fun testResolvingDidWithProofFromRegistryUrl() {
-    val registryDidResolver = customRegistryDidResolver { engine = mockEngine() }
     val didWithProof = registryDidResolver.getDidWithProof(VALID_URL, VALID_DAP_WITH_PROOF)
     assertEquals(VALID_DID.toString(), didWithProof.did.toString())
     assertEquals(VALID_PROOF, didWithProof.proof)
   }
 
   @Test
-  fun testResolvingDidWithExtraFieldsFromRegistryUrl() {
-    val registryDidResolver = customRegistryDidResolver { engine = mockEngine() }
-    val did = registryDidResolver.getUnprovenDid(VALID_URL, VALID_DAP_WITH_EXTRA_FIELDS)
-    assertEquals(VALID_DID.toString(), did.toString())
+  fun testErrorsFetchingFromRegistry() {
+    val errorDaps = listOf(
+      UNKNOWN_DAP to "Error fetching DAP from registry",
+      EMPTY_RESPONSE_DAP to "DAP registry did not return a DID",
+      INVALID_RESPONSE_DAP to "Failed to parse DAP registry response",
+      INVALID_DID_DAP to "Failed to parse DID from DAP registry response",
+    )
+    errorDaps.forEach { (dap, expectedMessage) ->
+      val exception = assertThrows<RegistryDidResolutionException> {
+        registryDidResolver.getUnprovenDid(VALID_URL, dap)
+      }
+      assertEquals(expectedMessage, exception.message)
+    }
   }
-
-  // TODO - tests for error cases
 
   private fun mockEngine() = MockEngine { request ->
     when (request.url.toString()) {
@@ -69,7 +73,7 @@ class RegistryDidResolverTest {
                 "did": "${VALID_PROOF.did}",
                 "domain": "${VALID_PROOF.domain}",
                 "signature": "${VALID_PROOF.signature}",
-                "extrafield": "extrafield"
+                "extra-field": "extra-field"
               }
             }
             """.trimMargin()
@@ -85,10 +89,34 @@ class RegistryDidResolverTest {
             """
             {
               "did": "$VALID_DID",
-              "extrafield": "extrafield"
+              "extra-field": "extra-field"
             }
             """.trimMargin()
           ),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+      }
+
+      "$VALID_URL/daps/${EMPTY_RESPONSE_DAP.handle}" -> {
+        respond(
+          content = ByteReadChannel("""{}"""),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+      }
+
+      "$VALID_URL/daps/${INVALID_RESPONSE_DAP.handle}" -> {
+        respond(
+          content = ByteReadChannel("""invalid-response"""),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+      }
+
+      "$VALID_URL/daps/${INVALID_DID_DAP.handle}" -> {
+        respond(
+          content = ByteReadChannel("""{"did": "invalid-did"}"""),
           status = HttpStatusCode.OK,
           headers = headersOf(HttpHeaders.ContentType, "application/json")
         )
@@ -102,7 +130,7 @@ class RegistryDidResolverTest {
     val VALID_URL = URL("https://didpay.me")
     val VALID_DAP = Dap("moegrammer", "didpay.me")
     val VALID_DAP_WITH_PROOF = Dap("proof", "didpay.me")
-    val VALID_DAP_WITH_EXTRA_FIELDS = Dap("extrafields", "didpay.me")
+    val VALID_DAP_WITH_EXTRA_FIELDS = Dap("extra-field", "didpay.me")
 
     val VALID_DID = Did.parse("did:web:didpay.me:moegrammer")
     val VALID_PROOF = Proof(
@@ -110,7 +138,13 @@ class RegistryDidResolverTest {
       domain = "didpay.me",
       handle = "moegrammer",
       id = "reg_01j13n944betnsesdve4ewc9c7",
-      signature = "signature",
+      signature = "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDp3ZWI6ZGlkcGF5Lm1lOm1vZWdyYW1tZXIjMCJ9.." +
+        "jD38MMEGR4q9mtupJZ_kNEI3RoqKhhBh3fpdkRUskhLIm0Mr3-5Egm0XflSxkFxyby3Mq8DhL71QImojWJQZCw",
     )
+
+    val UNKNOWN_DAP = Dap("i-don't-know-you", "didpay.me")
+    val EMPTY_RESPONSE_DAP = Dap("empty-response", "didpay.me")
+    val INVALID_RESPONSE_DAP = Dap("invalid-response", "didpay.me")
+    val INVALID_DID_DAP = Dap("invalid-did", "didpay.me")
   }
 }

--- a/src/test/kotlin/xyz/block/dap/RegistryDidResolverTest.kt
+++ b/src/test/kotlin/xyz/block/dap/RegistryDidResolverTest.kt
@@ -25,9 +25,23 @@ class RegistryDidResolverTest {
 
   @Test
   fun testResolvingDidFromRegistryUrl() {
-    val engine = mockEngine()
-    val registryDidResolver = RegistryDidResolver { engine }
-    val did = registryDidResolver.getDid(VALID_URL, VALID_DAP)
+    val registryDidResolver = customRegistryDidResolver { engine = mockEngine() }
+    val did = registryDidResolver.getUnprovenDid(VALID_URL, VALID_DAP)
+    assertEquals(VALID_DID.toString(), did.toString())
+  }
+
+  @Test
+  fun testResolvingDidWithProofFromRegistryUrl() {
+    val registryDidResolver = customRegistryDidResolver { engine = mockEngine() }
+    val didWithProof = registryDidResolver.getDidWithProof(VALID_URL, VALID_DAP_WITH_PROOF)
+    assertEquals(VALID_DID.toString(), didWithProof.did.toString())
+    assertEquals(VALID_PROOF, didWithProof.proof)
+  }
+
+  @Test
+  fun testResolvingDidWithExtraFieldsFromRegistryUrl() {
+    val registryDidResolver = customRegistryDidResolver { engine = mockEngine() }
+    val did = registryDidResolver.getUnprovenDid(VALID_URL, VALID_DAP_WITH_EXTRA_FIELDS)
     assertEquals(VALID_DID.toString(), did.toString())
   }
 
@@ -37,7 +51,44 @@ class RegistryDidResolverTest {
     when (request.url.toString()) {
       "$VALID_URL/daps/${VALID_DAP.handle}" -> {
         respond(
-          content = ByteReadChannel("""{did: "$VALID_DID"}"""),
+          content = ByteReadChannel("""{"did": "$VALID_DID"}"""),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+      }
+
+      "$VALID_URL/daps/${VALID_DAP_WITH_PROOF.handle}" -> {
+        respond(
+          content = ByteReadChannel(
+            """
+            {
+              "did": "$VALID_DID",
+              "proof": {
+                "id": "${VALID_PROOF.id}",
+                "handle": "${VALID_PROOF.handle}",
+                "did": "${VALID_PROOF.did}",
+                "domain": "${VALID_PROOF.domain}",
+                "signature": "${VALID_PROOF.signature}",
+                "extrafield": "extrafield"
+              }
+            }
+            """.trimMargin()
+          ),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "application/json")
+        )
+      }
+
+      "$VALID_URL/daps/${VALID_DAP_WITH_EXTRA_FIELDS.handle}" -> {
+        respond(
+          content = ByteReadChannel(
+            """
+            {
+              "did": "$VALID_DID",
+              "extrafield": "extrafield"
+            }
+            """.trimMargin()
+          ),
           status = HttpStatusCode.OK,
           headers = headersOf(HttpHeaders.ContentType, "application/json")
         )
@@ -50,6 +101,16 @@ class RegistryDidResolverTest {
   companion object {
     val VALID_URL = URL("https://didpay.me")
     val VALID_DAP = Dap("moegrammer", "didpay.me")
+    val VALID_DAP_WITH_PROOF = Dap("proof", "didpay.me")
+    val VALID_DAP_WITH_EXTRA_FIELDS = Dap("extrafields", "didpay.me")
+
     val VALID_DID = Did.parse("did:web:didpay.me:moegrammer")
+    val VALID_PROOF = Proof(
+      did = VALID_DID.toString(),
+      domain = "didpay.me",
+      handle = "moegrammer",
+      id = "reg_01j13n944betnsesdve4ewc9c7",
+      signature = "signature",
+    )
   }
 }


### PR DESCRIPTION
The RegistryDidResolver test was fetching from the `didpay.me` registry instead of using the mock engine. This was because the method to customize the configuration override was incorrect.

While looking into this I adjusted the way the override works to be based on the method used in web5-kt. Then I adjusted it slightly to make it look like normal constructor calls.

Also made it explicit that we do not verify the proof in the response from the registry, and added missing tests for the RegistryDidResolver.

